### PR TITLE
Use globals for standard output

### DIFF
--- a/lib/hexdump/dumper.rb
+++ b/lib/hexdump/dumper.rb
@@ -358,7 +358,7 @@ module Hexdump
     #
     # @since 0.2.0
     #
-    def dump(data,output=STDOUT)
+    def dump(data,output=$stdout)
       unless output.respond_to?(:<<)
         raise(ArgumentError,"output must support the #<< method")
       end

--- a/lib/hexdump/hexdump.rb
+++ b/lib/hexdump/hexdump.rb
@@ -45,7 +45,7 @@ module Hexdump
   # @option options [Boolean] :ascii (false)
   #   Print ascii characters when possible.
   #
-  # @option options [#<<] :output (STDOUT)
+  # @option options [#<<] :output ($stdout)
   #   The output to print the hexdump to.
   #
   # @yield [index,numeric,printable]
@@ -69,7 +69,7 @@ module Hexdump
   #   the `:base` value was unknown.
   #
   def Hexdump.dump(data,options={},&block)
-    output = (options.delete(:output) || STDOUT)
+    output = (options.delete(:output) || $stdout)
     dumper = Dumper.new(options)
 
     if block


### PR DESCRIPTION
Using `$stdout` instead of `STDOUT` makes hexdump output visible in IRuby. 
